### PR TITLE
Use base_url to calculate path in posts

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
             {% block content %}
             <div class="posts">
                 {% for page in section.pages %}
-                <a class="stretched" href="{{page.path}}">
+                <a class="stretched" href="{{config.base_url}}/{{page.path}}">
                     <div class="post-container">
                         <img data-src="{{page.extra.header_img}}" class="lozad" data-placeholder-background="darkgrey">
                         <div class="post-text">


### PR DESCRIPTION
This change allows to deploy when `base_url` ends in a URL path i.e https://agustinramirodiaz.github.io/architecture-showroom/. 

This works in development too since `base_url` is modified to your localhost port